### PR TITLE
Update to newest fluxapp structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,45 @@
 iso-fetch
 =========
 
-An isomorphic API proxy. It's part of FluxApp and shouldn't be used
-directly.
+An isomorphic API proxy, which currently supports jquery on the browser and hapi on the server. This module was created to compliment [Fluxapp](http://www.github.com/colonyamerican/fluxapp) actions and allow server and client to share the same code base.
 
-## Protocol
+## Installation
 
-Be advised that if your server response is a proper JSON with a `payload` key,
-the value under `payload` will be taken as a response. This allows us to pass
-additional metadata in the response.
+`npm install --save iso-fetch`
+
+## Usage with fluxapp
+
+### Hapi
+
+```js
+function handler(request, reply) {
+  const context = fluxApp.createContext({
+      fetcher: isoFetch('hapi', {
+        request: request
+      })
+  });  
+}
+```
+
+
+### jQuery (webpack or browserify)
+
+```js
+const context = fluxApp.createContext({
+  fetcher: isoFetch('jquery')
+});  
+```
+
+Using the above it will expose a method on our actions `this.context.fetcher(options)`, for both server side and client side usage.
+
+## Supported Options
+
+* url
+* method
+* headers
+* payload
+
 
 ## Writing your own transports
 
-Transports to other servers/clients are very welcome. A transport needs to export two
-functions, `request` and `init`. Both accept a single `Object` and are used to post the
-request and initialize the transport, respectively.
-
-Remember that only the reply contents has to be passed down the promise chain
-to the handler, the rest of the parameters (currently `statusCode` and `headers`)
-are need to be bound to `this`.
-
-The transport may be initialized with a cookie, if it's a server side
-transport. It will be passed in the second parameter to the initializing
-function, under the `cookie` key.
-
-When in doubt, consult the `hapi` and `jquery` transports.
+Take a look at the existing [Hapi](./lib/transports/hapi.js) and [jQuery](./lib/transports/jquery.js) implementations. The transport should expose a function that accepts a config object and return a function that accepts an options object.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,29 +1,18 @@
 'use strict';
-
-var R = require('ramda');
 var _ = require('lodash');
+var transports = require('./transports');
 
-function IsoFetch(initData, options) {
-  this.config = R.merge({
-    server: 'hapi',
-    client: 'jquery',
-    cookie: undefined
-  }, options || {});
+module.exports = function getFetcher(name) {
+  var fetcher = transports[name];
+  var args = _.toArray(arguments).slice(1);
 
-  this.transports = require('./transports');
-
-  _.forEach(initData, function(opts, transportName) {
-    this.transports[transportName].init(opts, this.config);
-  }, this);
-}
-
-IsoFetch.prototype.request = function request(requestData) {
-  if (this.config.current) {
-    return this.transports[this.config.current].request(requestData);
-  } else {
-    var env = typeof window === 'object' ? 'client' : 'server';
-    return this.transports[this.config[env]].request(requestData);
+  if (args.length) {
+    fetcher.bind(fetcher, args);
   }
-}
 
-module.exports = IsoFetch;
+  return {
+    contextMethods: {
+      fetch: fetcher;
+    }
+  };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,8 @@
 'use strict';
-var _ = require('lodash');
 var transports = require('./transports');
 
-module.exports = function getFetcher(name) {
+module.exports = function getFetcher(name, options) {
   var fetcher = transports[name];
-  var args = _.toArray(arguments).slice(1);
 
-  if (args.length) {
-    fetcher.bind(fetcher, args);
-  }
-
-  return fetcher;
+  return fetcher.bind(fetcher, options);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,5 @@ module.exports = function getFetcher(name) {
     fetcher.bind(fetcher, args);
   }
 
-  return {
-    contextMethods: {
-      fetch: fetcher;
-    }
-  };
+  return fetcher;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,19 @@
 'use strict';
 var transports = require('./transports');
+var _ = require('lodash');
 
 module.exports = function getFetcher(name, options) {
-  var fetcher = transports[name];
+  var fetcher = transports[name].bind(fetcher, options);
 
   options = options || {};
 
-  return fetcher.bind(fetcher, options);
+  return function formater(opts) {
+    if (_.isString(opts)) {
+      opts = {
+        url: opts
+      };
+    }
+    
+    return fetcher(opts);
+  };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,5 +4,7 @@ var transports = require('./transports');
 module.exports = function getFetcher(name, options) {
   var fetcher = transports[name];
 
+  options = options || {};
+
   return fetcher.bind(fetcher, options);
 };

--- a/lib/transports/hapi.js
+++ b/lib/transports/hapi.js
@@ -19,8 +19,14 @@ function parseResponse(payload) {
   return response;
 }
 
-module.exports = function hapiFetcher(request, opts) {
+module.exports = function hapiFetcher(config, opts) {
+  var request = config.request;
+
   return new Promise(function(resolve, reject) {
+    if (! request) {
+      throw new Error('iso-fetch:hapi requires a request option be set');
+    }
+
     if (! _.isPlainObject(opts) || _.keys(opts).length === 0) {
       return reject(new Error('Request options must be a non-empty object'));
     }

--- a/lib/transports/hapi.js
+++ b/lib/transports/hapi.js
@@ -1,14 +1,10 @@
 'use strict';
+var _ = require('lodash');
 var Promise = require('bluebird');
-var boom    = require('boom');
-var R       = require('ramda');
-var _       = require('lodash');
-
-var options = {};
-var cookie;
 
 function parseResponse(payload) {
   var response;
+
   try {
     response = JSON.parse(payload);
     response = response.payload ? response.payload : response;
@@ -23,24 +19,13 @@ function parseResponse(payload) {
   return response;
 }
 
-/**
- * Make an api request
- *
- * @param  {Object} options
- * @param  {Function} callback
- * @return {Promise}
- */
-function request(requestData) {
+module.exports = function hapiFetcher(request, opts) {
   return new Promise(function(resolve, reject) {
-    if (! _.isPlainObject(requestData) || R.keys(requestData).length === 0) {
-      return reject(new Error('Request data must be a non-empty object'));
+    if (! _.isPlainObject(opts) || _.keys(opts).length === 0) {
+      return reject(new Error('Request options must be a non-empty object'));
     }
 
-    requestData.headers = R.merge({
-      Cookie: cookie
-    }, requestData.headers || {});
-
-    options.server.inject(requestData, function requestResponse(res) {
+    request.server.inject(opts, function requestResponse(res) {
       var result = res.result;
       var statusCode = result && result.statusCode || res.statusCode;
 
@@ -59,14 +44,4 @@ function request(requestData) {
     _.assign(this, result);
     return result.result;
   });
-};
-
-function init(opts, globalConfig) {
-  options = opts;
-  cookie = globalConfig.cookie;
-}
-
-module.exports = {
-  request : request,
-  init    : init
 };

--- a/lib/transports/hapi.js
+++ b/lib/transports/hapi.js
@@ -22,11 +22,11 @@ function parseResponse(payload) {
 module.exports = function hapiFetcher(config, opts) {
   var request = config.request;
 
-  return new Promise(function(resolve, reject) {
-    if (! request) {
-      throw new Error('iso-fetch:hapi requires a request option be set');
-    }
+  if (! request) {
+    throw new Error('iso-fetch:hapi requires a request option be set');
+  }
 
+  return new Promise(function(resolve, reject) {
     if (! _.isPlainObject(opts) || _.keys(opts).length === 0) {
       return reject(new Error('Request options must be a non-empty object'));
     }

--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  hapi   : require('./hapi'),
-  jquery : require('./jquery')
+  hapi: require('./hapi'),
+  jquery: require('./jquery'),
 };

--- a/lib/transports/jquery.js
+++ b/lib/transports/jquery.js
@@ -11,7 +11,7 @@ var $       = require('jquery');
  * @param  {Function} callback
  * @return {Promise}
  */
-module.exports = function request(opts) {
+module.exports = function request(config, opts) {
   return new Promise(function(resolve, reject) {
     // enabled options
     // method=type, url=url, headers=headers, payload=data

--- a/lib/transports/jquery.js
+++ b/lib/transports/jquery.js
@@ -65,8 +65,3 @@ module.exports = function request(opts) {
     return result.result;
   });
 };
-
-module.exports = {
-  request : request,
-  init    : _.noop
-};

--- a/lib/transports/jquery.js
+++ b/lib/transports/jquery.js
@@ -11,8 +11,7 @@ var $       = require('jquery');
  * @param  {Function} callback
  * @return {Promise}
  */
-function request(opts) {
-
+module.exports = function request(opts) {
   return new Promise(function(resolve, reject) {
     // enabled options
     // method=type, url=url, headers=headers, payload=data

--- a/package.json
+++ b/package.json
@@ -18,9 +18,5 @@
     "boom": "^2.6.1",
     "jquery": "^2.1.1",
     "lodash": "^2.4.1"
-  },
-  "peerDependencies": {
-    "fluxapp": "^0.1.0"
   }
-  "readmeFilename": "README.md"
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "bluebird": "^2.3.11",
     "boom": "^2.6.1",
     "jquery": "^2.1.1",
-    "lodash": "^2.4.1",
-    "ramda": "^0.13.0"
+    "lodash": "^2.4.1"
   },
   "readmeFilename": "README.md"
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
     "jquery": "^2.1.1",
     "lodash": "^2.4.1"
   },
+  "peerDependencies": {
+    "fluxapp": "^0.1.0"
+  }
   "readmeFilename": "README.md"
 }


### PR DESCRIPTION
Updated to work as a context method on the newest fluxapp structure. Also allows us to pass the current request down to iso fetch and utilize it for a proper request on the server side. 

Most logic was left unchanged except if we pass a string it assumes it to be a url option and converts it.
